### PR TITLE
Fix React server issues and ensure proper setup

### DIFF
--- a/octofit-tracker/backend/package-lock.json
+++ b/octofit-tracker/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This pull request includes a small change to the `package-lock.json` file in the `octofit-tracker/backend` directory. The change updates the lockfile version to 3 and initializes the file structure.